### PR TITLE
resolve angular routing broken when app is built

### DIFF
--- a/cmd/templates/angular-template/frontend/src/app/app-routing.module.ts
+++ b/cmd/templates/angular-template/frontend/src/app/app-routing.module.ts
@@ -5,7 +5,7 @@ const routes: Routes = [];
 
 @NgModule({
   imports: [
-    RouterModule.forRoot(routes)
+    RouterModule.forRoot(routes,{useHash:true})
   ],
   exports: [RouterModule]
 })


### PR DESCRIPTION
As discovered in issue #497 angular routing is broken. The best fix I could find was to enable hash based routing which this small patch does.